### PR TITLE
Using ESM syntax for export

### DIFF
--- a/src/plotty.js
+++ b/src/plotty.js
@@ -636,4 +636,4 @@ class plot {
 }
 
 // register the symbols to be exported at the 'global' object (to be replaced by browserify)
-global.plotty = { plot, addColorScale, colorscales, renderColorScaleToCanvas };
+export { plot, addColorScale, colorscales, renderColorScaleToCanvas };


### PR DESCRIPTION
This allows modern bundlers like webpack and rollup to use plotty.

This PR https://github.com/santilland/plotty/pull/5/files broke the integration with sane bundlers (browserify is highly deprecated and unstandardised)

This is not an opinionated change, ESM are standardised and part of the web standard:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export

cc @santilland 