### PR TITLE
Fix transparent colorscales in WebGL

### DIFF
--- a/src/plotty.js
+++ b/src/plotty.js
@@ -248,6 +248,7 @@ class plot {
         this.gl = gl;
         this.program = createProgram(gl, vertexShaderSource, fragmentShaderSource);
         gl.useProgram(this.program);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
 
         // look up where the vertex data needs to go.
         const texCoordLocation = gl.getAttribLocation(this.program, 'a_texCoord');

--- a/src/plotty.js
+++ b/src/plotty.js
@@ -243,12 +243,11 @@ class plot {
     if (defaultFor(options.useWebGL, true)) {
       // Try to create a webgl context in a temporary canvas to see if webgl and
       // required OES_texture_float is supported
-      if (create3DContext(document.createElement('canvas')) !== null) {
-        const gl = create3DContext(this.canvas);
+      if (create3DContext(document.createElement('canvas'), {premultipliedAlpha: false}) !== null) {
+        const gl = create3DContext(this.canvas, {premultipliedAlpha: false});
         this.gl = gl;
         this.program = createProgram(gl, vertexShaderSource, fragmentShaderSource);
         gl.useProgram(this.program);
-        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
 
         // look up where the vertex data needs to go.
         const texCoordLocation = gl.getAttribLocation(this.program, 'a_texCoord');


### PR DESCRIPTION
This should fix issue #37

After some research, I think it is only a matter of finding the correct WebGL settings to blend transparent colors appropriately.
For that, I used method 5 from https://webglfundamentals.org/webgl/lessons/webgl-and-alpha.html.