### PR TITLE
NaN Values - Fix FragmentShaderSource to check for NaN value using idempotency

### DIFF
--- a/src/plotty.js
+++ b/src/plotty.js
@@ -189,7 +189,7 @@ void main() {
   float value = texture2D(u_textureData, v_texCoord)[0];
   if(value < -3.402823466e+38) // Check for possible NaN value
     gl_FragColor = vec4(0.0, 0, 0, 0.0);
-  else if (value == u_noDataValue)
+  else if (value == u_noDataValue || value != value)
     gl_FragColor = vec4(0.0, 0, 0, 0.0);
   else if (u_apply_display_range && (value < u_display_range[0] || value >= u_display_range[1]))
         gl_FragColor = vec4(0.0, 0, 0, 0.0);


### PR DESCRIPTION
### Problem

Similar to #20 

I have a raster file that has NaN values, but these values are being rendered.

It appears that a fix was made here (https://github.com/santilland/plotty/commit/b161a129b41eaa1c0d54e3c26e036de88d0152ff), but it doesn't appear to be making the NaN values transparent.

I have an example of this here: https://codepen.io/gpbmike/pen/mdqqJaV

### Solution

Use the pattern in https://github.com/santilland/plotty/commit/b161a129b41eaa1c0d54e3c26e036de88d0152ff to check if the value is NaN in the FragmentShaderSource.