### PR TITLE
Fix FragmentShaderSource to handle NaN values in Windows

### DIFF
--- a/src/plotty.js
+++ b/src/plotty.js
@@ -184,12 +184,17 @@ uniform bool u_clampLow;
 uniform bool u_clampHigh;
 // the texCoords passed in from the vertex shader.
 varying vec2 v_texCoord;
+
+bool isnan( float val ) {
+  return ( val < 0.0 || 0.0 < val || val == 0.0 ) ? false : true;
+}
+
 void main() {
   vec2 onePixel = vec2(1.0, 1.0) / u_textureSize;
   float value = texture2D(u_textureData, v_texCoord)[0];
   if(value < -3.402823466e+38) // Check for possible NaN value
     gl_FragColor = vec4(0.0, 0, 0, 0.0);
-  else if (value == u_noDataValue || value != value)
+  else if (value == u_noDataValue || isnan(value))
     gl_FragColor = vec4(0.0, 0, 0, 0.0);
   else if (u_apply_display_range && (value < u_display_range[0] || value >= u_display_range[1]))
         gl_FragColor = vec4(0.0, 0, 0, 0.0);


### PR DESCRIPTION
Problem
Similar to https://github.com/santilland/plotty/pull/44

issue: #20 

I have a raster file with NaN values working in chrome on OSX that still renders NaN values in chrome on Windows.

I previously made a fix that fixed this issue in chrome on OSX but it looks like it didn't fix the issue in chrome on Windows.

I have an example of this here: https://codepen.io/dulldrums/pen/BaJQERE Open this in chrome on OSX and test it, then open it in Windows and notice it will render the NaN values

Solution
Use a pattern found in https://stackoverflow.com/a/34276128
Define a function called `isnan` and use that in the conditional. Confirmed this works on my windows machine and osx machine.